### PR TITLE
fix: fetch JS and CSS files from CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,22 @@
   <head>
     <meta charset="utf-8" />
     <title>sx127x setup</title>
-    <link rel="stylesheet" href="./highlight/styles/default.min.css">
-    <script src="./highlight/highlight.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/styles/default.min.css"
+      integrity="sha512-hasIneQUHlh06VNBe7f6ZcHmeRTLIaQWFd43YriJ0UND19bvYRauxthDg8E4eVNPm9bRUhr5JGeqH7FRFXQu5g=="
+      crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.4.0/highlight.min.js"
+      integrity="sha512-IaaKO80nPNs5j+VLxd42eK/7sYuXQmr+fyywCNA0e+C6gtQnuCXNtORe9xR4LqGPz5U9VpH+ff41wKs/ZmC3iA=="
+      crossorigin="anonymous" referrerpolicy="no-referrer"></script>
     <script src="./index.js"></script>
-    <link rel="stylesheet" href="./jqm/jquery.mobile-1.4.5.min.css">
-    <script src="./jqm/js/jquery.js"></script>
-    <script src="./jqm/js/jquery.mobile-1.4.5.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-mobile/1.4.1/jquery.mobile.min.css"
+      integrity="sha512-o3x4nST+KCWWUxaA1oneL8MOaOz8EEG+r6IUASMYlYd+ehohuxEr6Tv3XxZNkwHZgn3rw4r2D8N868O099HgyQ=="
+      crossorigin="anonymous" referrerpolicy="no-referrer" />
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+      integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ=="
+      crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-mobile/1.4.1/jquery.mobile.min.js"
+      integrity="sha512-wSacGPS/KRyVB67O4xD+Eh1OX4/dq4juZj9DKTokRt81BzLbfsSMtNgR9Pu8FLr4kLbk5oNr9Hq+5PeWLCX8mA=="
+      crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   </head>
   <body>
     <div class="ui-field-contain">


### PR DESCRIPTION
# Before

Jquery and Highlight JS/CSS files are not being fetched.

## Website
![Screenshot 2022-02-26 at 4 33 59 PM](https://user-images.githubusercontent.com/413879/155836411-cf58a5bd-dc8c-4be8-be3a-c018db38f89a.png)

## Network
![Screenshot 2022-02-26 at 4 34 25 PM](https://user-images.githubusercontent.com/413879/155836418-f6a09b4e-6ede-46df-9fc2-c6b3f3e40d54.png)

# After

## Website
![Screenshot 2022-02-26 at 4 33 04 PM](https://user-images.githubusercontent.com/413879/155836425-a70a2425-932b-4bb8-a563-c5efe0893cfb.png)

## Network
![Screenshot 2022-02-26 at 4 32 10 PM](https://user-images.githubusercontent.com/413879/155836427-436d6e5c-7dea-472d-8671-7f776c92158d.png)

@Kongduino Please help to check whether this pull request still makes the features work 😄  I have fetched the files from CDN instead.






